### PR TITLE
Check correctly if a fruit/vegetable is in season on FoodPage

### DIFF
--- a/android/app/src/main/java/org/fuzue/seasonfood/MainActivity.java
+++ b/android/app/src/main/java/org/fuzue/seasonfood/MainActivity.java
@@ -1,0 +1,5 @@
+package org.fuzue.seasonfood;
+
+import com.getcapacitor.BridgeActivity;
+
+public class MainActivity extends BridgeActivity {}

--- a/src/routes/FoodPage.tsx
+++ b/src/routes/FoodPage.tsx
@@ -31,7 +31,7 @@ export default function FoodPage() {
     if (selectedFood && selectedFood.season[i] === true) {
       seasonMonths.push(months[i]);
       seasonStatus = "FoodPage_notInSeasonText";
-      if (seasonMonths.includes(months[currentMonth])) {
+      if (seasonMonths.includes(months[currentMonth - 1])) {
         seasonStatus = "FoodPage_inSeasonText";
       }
     }


### PR DESCRIPTION
We forgot to change the currentMonth to count starting from 0 instead of 1.

Fix #76